### PR TITLE
Staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,22 +25,16 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install dependencies
+    - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install python-semantic-release build
-
-    - name: Configure git
-      run: |
-        git config --global user.name "semantic-release"
-        git config --global user.email "semantic-release@github.com"
+        pip install build
 
     - name: Python Semantic Release
       id: release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        semantic-release publish -vv
+      uses: python-semantic-release/python-semantic-release@v10.2.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload to PyPI (if enabled)
       if: steps.release.outputs.released == 'true' && false
@@ -55,4 +49,5 @@ jobs:
       if: steps.release.outputs.released == 'true'
       run: |
         echo "Released version: ${{ steps.release.outputs.version }}"
-        echo "Release notes: ${{ steps.release.outputs.release_notes }}"
+        echo "Release tag: ${{ steps.release.outputs.tag }}"
+        echo "Is prerelease: ${{ steps.release.outputs.is_prerelease }}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,12 @@ from typing import List
 # Add the project root to the Python path
 sys.path.insert(0, os.path.abspath("../src"))
 
-# Import version from the package
-from configurables import __version__
+# Read version from _version.py file to avoid import issues
+version_file = os.path.join(os.path.dirname(__file__), "../src/configurables/_version.py")
+with open(version_file) as f:
+    for line in f:
+        if line.startswith("__version__"):
+            __version__ = line.split("=")[1].strip().strip('"')
 
 
 # -- General configuration ---------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,12 @@ exclude = "docs"
 
 [tool.semantic_release]
 branch = "master"
-version_variable = "src/configurables/_version.py:__version__"
-version_toml = ["pyproject.toml:project.version"]
-version_pattern = "docs/conf.py:version = '{version}'"
+version_variable = [
+    "src/configurables/_version.py:__version__"
+]
+version_toml = [
+    "pyproject.toml:project.version"
+]
 upload_to_pypi = false
 upload_to_release = true
 build_command = "python -m build"


### PR DESCRIPTION
This pull request includes updates to the release workflow, version management, and documentation configuration. The most significant changes involve simplifying the release process, improving version handling, and aligning configuration files with best practices.

### Workflow and Release Process Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R37): Updated the release workflow to use the `python-semantic-release` GitHub Action instead of manual configuration steps. This change simplifies the setup by removing explicit Git configuration and directly integrating with the action. Additionally, updated the output to include `release tag` and `is prerelease` fields. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L28-R37) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L58-R53)

### Version Management Improvements:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L65-R70): Refactored the `version_variable` and `version_toml` fields to use a cleaner list format for better readability and maintainability. Removed the `version_pattern` field, as it is no longer needed.

### Documentation Configuration:
* [`docs/conf.py`](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L27-R32): Changed the method of retrieving the version to read it directly from the `_version.py` file instead of importing it, avoiding potential import issues during documentation builds.