### PR TITLE
fix(ci): skip build step to avoid missing dependencies in Docker cont…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,16 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install build dependencies
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build
 
     - name: Python Semantic Release
       id: release
       uses: python-semantic-release/python-semantic-release@v10.2.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        build: false
 
     - name: Upload to PyPI (if enabled)
       if: steps.release.outputs.released == 'true' && false


### PR DESCRIPTION
…ainer

The python-semantic-release GitHub Action runs in a Docker container that doesn't have access to packages installed in the workflow. This causes the build command to fail when trying to run 'python -m build'.

Changes:
- Add 'build: false' to skip the build step in semantic-release
- Remove build package installation as it's no longer needed
- Rename step from "Install build dependencies" to "Install dependencies"

This fixes the "No module named build" error in the GitHub Actions workflow. Distribution packages can be built separately if needed.

🤖 Generated with [Claude Code](https://claude.ai/code)